### PR TITLE
Fix piwik.js, so it matches documentation. …

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ gem install jekyll-analytics
 ## Configuration
 Edit `_config.yml` to use the plugin:
 ```
-gems:
+plugins:
   - jekyll-analytics
 ```
 

--- a/lib/analytics/Piwik.rb
+++ b/lib/analytics/Piwik.rb
@@ -6,11 +6,11 @@ class Piwik
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
     (function() {
-    var u=\"%{url}\";
+    var u='//'+\"%{url}\";
     _paq.push(['setTrackerUrl', u+'/piwik.php']);
     _paq.push(['setSiteId', '%{siteId}']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'/piwik.js'; s.parentNode.insertBefore(g,s);
     })();
     </script>
     <!-- End Piwik Code -->

--- a/test/PiwikTest.rb
+++ b/test/PiwikTest.rb
@@ -18,11 +18,11 @@ class PiwikTest < Test::Unit::TestCase
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
     (function() {
-    var u=\"my.piwik.server/path\";
+    var u=\'//\'+\"my.piwik.server/path\";
     _paq.push(['setTrackerUrl', u+'/piwik.php']);
     _paq.push(['setSiteId', '1']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'/piwik.js'; s.parentNode.insertBefore(g,s);
     })();
     </script>
     <!-- End Piwik Code -->


### PR DESCRIPTION
…`gems` is deprecated in _config.yml. Replaced it with `plugins`.

Documentation refers to the script which is outputted in [this step of the 5-min installation guide](https://piwik.org/docs/installation/#install-the-javascript-tracking-tag).