### PR TITLE
added code to improve tracking for single site pages

### DIFF
--- a/lib/analytics/GoogleAnalytics.rb
+++ b/lib/analytics/GoogleAnalytics.rb
@@ -16,7 +16,7 @@ class GoogleAnalytics
     ID_RE = /^UA-\d+-\d+$/    
 
     INITIALIZE_CODE = "ga('create', '%s', 'auto');"
-    PAGEVIEW_CODE = "ga('send', 'pageview');"
+    PAGEVIEW_CODE = "ga('send', 'pageview', { 'page': location.pathname + location.search + location.hash});"
     ANONYMIZE_IP_CODE = "ga('set', 'anonymizeIp', %s);"
 
 

--- a/test/GoogleAnalyticsTest.rb
+++ b/test/GoogleAnalyticsTest.rb
@@ -19,7 +19,7 @@ class TestGoogleAnalytics < Test::Unit::TestCase
     })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
     ga('create', 'UA-123-456', 'auto');
-\tga('send', 'pageview');
+\tga('send', 'pageview', { 'page': location.pathname + location.search + location.hash});
 \tga('set', 'anonymizeIp', false);
     </script>
     <!-- End Google Analytics -->


### PR DESCRIPTION
For improved tracking in google analytics I suggest using a script taken from here:
https://mediacause.org/track-anchor-tags-google-analytics-2/

With anchor support the website report is much more verbose. Otherwise I just see a single access to the index.html, i.e. the single page.