### PR TITLE
Fixed matomo script that prevent the plugin to compile

### DIFF
--- a/lib/analytics/Matomo.rb
+++ b/lib/analytics/Matomo.rb
@@ -1,7 +1,7 @@
 class Piwik
     SETUP_CODE = """
     <!-- Matomo -->
-    <script type="text/javascript">
+    <script type=\"text/javascript\">
       var _paq = _paq || [];
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);


### PR DESCRIPTION
Missing escaping characters on Matomo script prevented the plugin to compile