### PR TITLE
fix for Matomo url issue

### DIFF
--- a/jekyll-analytics.gemspec
+++ b/jekyll-analytics.gemspec
@@ -1,8 +1,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'jekyll-analytics'
-  s.version     = '0.1.9'
-  s.date        = '2018-02-03'
+  s.version     = '0.1.10'
+  s.date        = '2018-03-04'
   s.summary     = "Jekyll plugin "
   s.description = "Plugin to easily add web analytics to your jekyll site without modifying your templates. Supported are: Google Analytics, Piwik, Matomo, MPulse"
   s.authors     = ["Hendrik Schneider"]

--- a/lib/analytics/Matomo.rb
+++ b/lib/analytics/Matomo.rb
@@ -7,7 +7,7 @@ class Matomo
       _paq.push(['enableLinkTracking']);
       (function() {
         var u='//'+\"%{url}\";
-        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setTrackerUrl', u+'/piwik.php']);
         _paq.push(['setSiteId', '%{siteId}']);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'/piwik.js'; s.parentNode.insertBefore(g,s);


### PR DESCRIPTION
missing forward slash on line 10 of `./lib/analytics/Matomo.rb`

Unable to contact server, added forward slash on line 10, now works in my test and production environment. 