### PR TITLE
Move test gems to test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,9 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-# gem "rails"
-
-gem "simplecov", "~> 0.17.1"
-
-gem "simplecov-rcov", "~> 0.2.3"
-
-gem "rake", "~> 13.0"
-
-gem "test-unit", "~> 3.3"
+group :test do
+  gem "simplecov", "~> 0.17.1"
+  gem "simplecov-rcov", "~> 0.2.3"
+  gem "rake", "~> 13.0"
+  gem "test-unit", "~> 3.3"
+end


### PR DESCRIPTION
In a production environment I don't need or really want any of those dependencies. You can install them with ``bundle install --with=test``.