### PR TITLE
Fetch the correct "anonymizeIp" config

### DIFF
--- a/lib/analytics/GoogleAnalytics.rb
+++ b/lib/analytics/GoogleAnalytics.rb
@@ -38,6 +38,6 @@ class GoogleAnalytics
     private
 
     def _get_other_commands(config)
-        @commands.push(ANONYMIZE_IP_CODE % config.fetch(:anonymizeIp, false))
+        @commands.push(ANONYMIZE_IP_CODE % config.fetch("anonymizeIp", false))
     end
 end

--- a/test/GoogleAnalyticsTest.rb
+++ b/test/GoogleAnalyticsTest.rb
@@ -28,7 +28,7 @@ class TestGoogleAnalytics < Test::Unit::TestCase
 
     def test_anonymize_true
         googleAnalytics = GoogleAnalytics.new( {"id" => "UA-123-456", "anonymizeIp" => true} )
-        assert_match(/\('set', 'anonymizeIp', false\);/, googleAnalytics.render())
+        assert_match(/\('set', 'anonymizeIp', true\);/, googleAnalytics.render())
     end
 
 end


### PR DESCRIPTION
Something in jekyll (at least on my 4.0 install) stringifies all config
keys, so `:anonymizeIp` did never fetch the real value.

This change fixes that.