### PR TITLE
plausible: Additional option for 404 error pages tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ jekyll_analytics:
 
   Plausible:
     domain: 'example.com'   # The domain configured in plausible
-    source: 'https://plausible.example.com/js/plausible.js' # The source of the javascript
+    source: 'https://plausible.example.com/js/plausible.js' # The source URL of the javascript,
+    404_tracking: true      # Enable 404 error tracking. Also requires changes to your webserver and 404.md
+                            # See https://plausible.io/docs/404-error-pages-tracking for other set up required
+
 ```
 
 ## Usage

--- a/lib/analytics/plausible.rb
+++ b/lib/analytics/plausible.rb
@@ -2,9 +2,14 @@ class Plausible
     def initialize(config)
         @domain = config['domain']
         @source = config['source']
+        @not_found = !!config['404_tracking']
     end
 
     def render()
-        return "<script async defer data-domain=\"#{@domain}\" src=\"#{@source}\"></script>"
+        tag = "<script async defer data-domain=\"#{@domain}\" src=\"#{@source}\"></script>"
+        if @not_found
+            tag += "<script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>"
+        end
+        return tag
     end
 end


### PR DESCRIPTION
This adds docs and implementation to set up the script part
of Plausible's 404 tracking as described in https://plausible.io/docs/404-error-pages-tracking