### PR TITLE
Add Cloudflare Web Analytics as a tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Supported:
   - [Piwik](https://piwik.org/)
   - [mPulse](https://www.soasta.com/performance-monitoring/)
   - [Plausible](https://plausible.io)
+  - [Cloudflare Web Analytics](https://www.cloudflare.com/web-analytics/)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ jekyll_analytics:
   Plausible:
     domain: 'example.com'   # The domain configured in plausible
     source: 'https://plausible.example.com/js/plausible.js' # The source of the javascript
+
+  CloudflareWebAnalytics:   # Add if you want to track with Cloudflare Web Analytics
+    cf_beacon_token: 'abcdefghijklmnopqrstuvwxyz1234568' # Required - replace with your beacon token (in the script tag: `data-cf-beacon`).
 ```
 
 ## Usage

--- a/lib/analytics/CloudflareWebAnalytics.rb
+++ b/lib/analytics/CloudflareWebAnalytics.rb
@@ -1,0 +1,25 @@
+class CloudflareWebAnalytics
+    #source: https://support.cloudflare.com/hc/en-us/articles/360052685432-Cloudflare-Web-Analytics
+    SETUP_CODE = """
+    <!-- Cloudflare Web Analytics -->
+    <script defer
+    src='https://static.cloudflareinsights.com/beacon.min.js'
+    data-cf-beacon='{\"token\": \"%{cf_beacon_token}\"}'></script>
+    <!-- End Cloudflare Web Analytics -->
+    """
+
+    # Cloudflare Web Analytics site tokens are alphanumeric strings.
+    CLOUDFLARE_SITE_TOKEN_RE = /^[a-zA-Z0-9]+$/
+
+    def initialize(config)
+        if !(CLOUDFLARE_SITE_TOKEN_RE.match(config['cf_beacon_token']))
+            raise ArgumentError, 'Invalid Cloudflare Web Analytics token. Must be alphanumeric string.'
+        end
+
+        @config = Hash[config.map{ |k, v| [k.to_sym, v.to_s] }]
+    end
+
+    def render
+      return SETUP_CODE % @config
+    end
+end

--- a/test/CloudflareWebAnalyticsTest.rb
+++ b/test/CloudflareWebAnalyticsTest.rb
@@ -1,0 +1,27 @@
+require_relative "../lib/analytics/CloudflareWebAnalytics.rb"
+require "test/unit"
+
+class CloudflareWebAnalyticsTest < Test::Unit::TestCase
+    def test_init
+        # Token must be supplied.
+        assert_raise( ArgumentError ) { CloudflareWebAnalytics.new() }
+
+        # Token must be alphanumeric.
+        assert_raise( ArgumentError ) { CloudflareWebAnalytics.new( {"cf_beacon_token" => "_1a2345b6c789012defgh23456ij7890"} ) }
+        assert_instance_of(CloudflareWebAnalytics, CloudflareWebAnalytics.new( {"cf_beacon_token" => "01a2345b6c789012defgh23456ij7890"} ))
+    end
+
+    def test_default_tracking_string
+        cloudflareWebAnalytics = CloudflareWebAnalytics.new( {"cf_beacon_token" => "01a2345b6c789012defgh23456ij7890"} )
+
+        # Script renders correctly.
+        assert_equal(cloudflareWebAnalytics.render(),
+        """
+    <!-- Cloudflare Web Analytics -->
+    <script defer
+    src='https://static.cloudflareinsights.com/beacon.min.js'
+    data-cf-beacon='{\"token\": \"01a2345b6c789012defgh23456ij7890\"}'></script>
+    <!-- End Cloudflare Web Analytics -->
+    """)
+    end
+end

--- a/test/test_all.rb
+++ b/test/test_all.rb
@@ -1,3 +1,4 @@
+require_relative "CloudflareWebAnalyticsTest"
 require_relative "GoogleAnalyticsTest"
 require_relative "PiwikTest"
 require_relative "mPulseTest"


### PR DESCRIPTION
Cloudflare has recently released their web analytics platform and it is available for integration.

Cloudflare Web Analytics is marketed as, "Privacy-first, lightweight, accurate web analytics—for free".

This PR includes the basic script tag allowing users to install the analytics script more simply if they're already using `jekyll-analytics`.

This PR does not include the more advanced functionality (disabling SPA tracking, or GTM integration) as those require a more advanced configuration with some additional conditionals. If they're deemed desirable they can be added, but I think someone more familiar with the `jekyll-analytics` gem would need to consult on them.