### PR TITLE
Add script tag formatted for Google Analytics 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ Configure the plugin in `_config.yml` by adding:
 
 ```yml
 jekyll_analytics:
-  GoogleAnalytics:          # Add, if you want to track with Google Analytics
+  GoogleAnalytics:          # Add, if you want to track with Google Analytics (Legacy)
     id: UA-123-456          # Required - replace with your tracking id
     anonymizeIp: false      # Optional - Default: false - set to true for anonymized tracking
+
+  GoogleAnalytics4:          # Add, if you want to track with Google Analytics 4
+    measurement_id: G-1234567890 # Required - replace with your measurement id
 
   Matomo:                   # Add, if you want to track with Matomo (former Piwik Analytics)
     url: matomo.example.com # Required - url to Matomo installation without trailing /
@@ -62,6 +65,10 @@ jekyll_analytics:
     domain: 'example.com'   # The domain configured in plausible
     source: 'https://plausible.example.com/js/plausible.js' # The source of the javascript
 ```
+
+<aside>
+Google Analytics (legacy) with a `UA-` ID and Google Analytics 4 with a `G-` ID can be used simultaneously.
+</aside>
 
 ## Usage
 Tracking will be disabled in development mode. To enable production mode set enviroment variable JEKYLL_ENV=production.

--- a/lib/analytics/GoogleAnalytics4.rb
+++ b/lib/analytics/GoogleAnalytics4.rb
@@ -15,8 +15,6 @@ class GoogleAnalytics4
     VALID_G_ID_RE = /\A^G-[a-zA-z\d]+\z/
     VALID_UA_ID_RE = /\A(?i)(UA|YT|MO).+$\z/
 
-    CONFIG_JS = "ga('create', '%s', 'auto');"
-
    def initialize(config)
         if (VALID_UA_ID_RE.match(config["measurement_id"]))
             # The user has used an incompatible ID.

--- a/lib/analytics/GoogleAnalytics4.rb
+++ b/lib/analytics/GoogleAnalytics4.rb
@@ -1,0 +1,37 @@
+class GoogleAnalytics4
+    #source: https://developers.google.com/analytics/devguides/collection/analyticsjs/
+    SETUP_CODE = """
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src=\"https://www.googletagmanager.com/gtag/js?id=%{measurement_id}\"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', '%{measurement_id}');
+    </script>
+    """
+
+    VALID_G_ID_RE = /\A^G-[a-zA-z\d]+\z/
+    VALID_UA_ID_RE = /\A(?i)(UA|YT|MO).+$\z/
+
+    CONFIG_JS = "ga('create', '%s', 'auto');"
+
+   def initialize(config)
+        if (VALID_UA_ID_RE.match(config["measurement_id"]))
+            # The user has used an incompatible ID.
+            raise ArgumentError, 'Use a Measurement ID beginning with "G-". IDs starting with "UA" (or "YT", or "MO") are not compatible with Google Analytics 4.'
+        end
+
+        if !(VALID_G_ID_RE.match(config["measurement_id"]))
+            # The user has used a malformed ID.
+            raise ArgumentError, 'A Google Analytics 4 Measurement ID must begin with "G-".'
+        end
+
+        @config = Hash[config.map{ |k, v| [k.to_sym, v.to_s] }]
+    end
+
+    def render()
+        return SETUP_CODE % @config
+    end
+end

--- a/test/GoogleAnalytics4Test.rb
+++ b/test/GoogleAnalytics4Test.rb
@@ -1,0 +1,35 @@
+require_relative "../lib/analytics/GoogleAnalytics4.rb"
+require "test/unit"
+
+class GoogleAnalytics4Test < Test::Unit::TestCase
+    def test_init
+        # Measurement ID must begin with a `G-`.
+        assert_raise( ArgumentError ) { GoogleAnalytics4.new( {"measurement_id" => "1234567890"} ) }
+
+        # Measurement ID must not begin with a `UA-`, `YT-`, or `MO-` (Legacy Google Analytics).
+        # User should be informed of their error and the fix.
+        assert_raise( ArgumentError ) { GoogleAnalytics4.new( {"measurement_id" => "UA-12346789-0"} ) } # Valid UA
+        assert_raise( ArgumentError ) { GoogleAnalytics4.new( {"measurement_id" => "UA-12346789"} ) } # Invalid UA
+        assert_raise( ArgumentError ) { GoogleAnalytics4.new( {"measurement_id" => "YT-1234-56"} ) } # Valid YT
+        assert_raise( ArgumentError ) { GoogleAnalytics4.new( {"measurement_id" => "MO-1-1"} ) } # Valid MO
+
+        # Measurement ID begins with `G-` and is followed by digits.
+        assert_instance_of(GoogleAnalytics4, GoogleAnalytics4.new( {"measurement_id" => "G-1234567890"} ))
+    end
+
+    def test_default_tracking_string
+        googleAnalytics4 = GoogleAnalytics4.new( {"measurement_id" => "G-1234567890"} )
+        assert_equal(googleAnalytics4.render(),
+        """
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src=\"https://www.googletagmanager.com/gtag/js?id=G-1234567890\"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-1234567890');
+    </script>
+    """)
+    end
+end

--- a/test/test_all.rb
+++ b/test/test_all.rb
@@ -1,3 +1,4 @@
 require_relative "GoogleAnalyticsTest"
+require_relative "GoogleAnalytics4Test"
 require_relative "PiwikTest"
 require_relative "mPulseTest"


### PR DESCRIPTION
Google Analytics 4 uses _gtag.js_, and has removed the `UA` code. Both Google Analytics 4 and legacy can be run at the same time on the same site (to support legacy users).

It made sense to build a second class so that config allows both, either, or none to be supported; and the config file just needs to ammended appropriately.

This addresses #49.