### PR TITLE
Inject analytics in any collection document (not just posts).

### DIFF
--- a/lib/jekyll-analytics.rb
+++ b/lib/jekyll-analytics.rb
@@ -17,8 +17,8 @@ Jekyll::Hooks.register :pages, :post_render do |page|
   inject(page)
 end
 
-Jekyll::Hooks.register :posts, :post_render do |post|
-  inject(post)
+Jekyll::Hooks.register :documents, :post_render do |document|
+  inject(document)
 end
 
 Jekyll::Hooks.register :site, :post_render do |site|


### PR DESCRIPTION
Instead of only injecting analytics headers into the `posts` collection, inject into `documents` instead.
This covers any type of collection and is a flexible solution to issue #66 .

See mentioning of `documents` in: https://jekyllrb.com/docs/plugins/hooks/ 