### PR TITLE
Fix counter dot dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ jekyll_analytics:
   CounterDotDev:
     data_id: "uuid" # Found in the tracking code/script when you add a website in CounterDotDev
     source: "https://cdn.counter.dev/script.js" # The source of the javascript
-    data_utc_offset: 8
+    data_utc_offset: "8"
 
   PostHog:
     url: "https://us.i.posthog.com" # Required - replace with the url of post hog analytics

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ jekyll_analytics:
   CounterDotDev:
     data_id: "uuid" # Found in the tracking code/script when you add a website in CounterDotDev
     source: "https://cdn.counter.dev/script.js" # The source of the javascript
-    data_utc_offset: "8"
+    data_utc_offset: "8" # UTC offset for the timezone you would want the data to be in.
 
   PostHog:
     url: "https://us.i.posthog.com" # Required - replace with the url of post hog analytics

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/a07904b989dcb7e4e477/maintainability)](https://codeclimate.com/github/hendrikschneider/jekyll-analytics/maintainability)
 
 # Jekyll::analytics
+
 Webanalytics for Jekyll.
 
 There are many tutorials online to add analytics to Jekyll by extending the template. Jekyll-analytics is here to take care of this. Just install the plugin, configure it and you are done :)
@@ -10,13 +11,14 @@ There are many tutorials online to add analytics to Jekyll by extending the temp
 Jekyll-analytics: Webanalytics made easy.
 
 Supported:
-  - [Google Analytics](https://analytics.google.com/analytics/web/)
-  - [Matomo](https://matomo.org/)
-  - [Piwik](https://piwik.org/)
-  - [mPulse](https://www.soasta.com/performance-monitoring/)
-  - [Plausible](https://plausible.io)
-  - [Counter](https://counter.dev/)
-  - [PostHog](https://posthog.com/)
+
+- [Google Analytics](https://analytics.google.com/analytics/web/)
+- [Matomo](https://matomo.org/)
+- [Piwik](https://piwik.org/)
+- [mPulse](https://www.soasta.com/performance-monitoring/)
+- [Plausible](https://plausible.io)
+- [Counter](https://counter.dev/)
+- [PostHog](https://posthog.com/)
 
 ## Installation
 
@@ -25,17 +27,23 @@ Add this to your `Gemfile`:
 ```
 gem 'jekyll-analytics'
 ```
+
 Then execute
+
 ```
 $ bundle
 ```
+
 Or install it yourself
+
 ```
 gem install jekyll-analytics
 ```
 
 ## Configuration
+
 Edit `_config.yml` to use the plugin:
+
 ```
 plugins:
   - jekyll-analytics
@@ -45,35 +53,37 @@ Configure the plugin in `_config.yml` by adding:
 
 ```yml
 jekyll_analytics:
-  GoogleAnalytics:          # Add, if you want to track with Google Analytics
-    id: UA-123-456          # Required - replace with your tracking id
-    anonymizeIp: false      # Optional - Default: false - set to true for anonymized tracking
+  GoogleAnalytics: # Add, if you want to track with Google Analytics
+    id: UA-123-456 # Required - replace with your tracking id
+    anonymizeIp: false # Optional - Default: false - set to true for anonymized tracking
 
-  Matomo:                   # Add, if you want to track with Matomo (former Piwik Analytics)
+  Matomo: # Add, if you want to track with Matomo (former Piwik Analytics)
     url: matomo.example.com # Required - url to Matomo installation without trailing /
-    siteId: "1234"          # Required - replace with your Matomo site id (Write id as string)
+    siteId: "1234" # Required - replace with your Matomo site id (Write id as string)
 
-  Piwik:                    # Add, if you want to track with Piwik
-    url: piwik.example.com  # Required - url to Piwik installation without trailing /
-    siteId: "1234"          # Required - replace with your Piwik site id (Write id as string)
+  Piwik: # Add, if you want to track with Piwik
+    url: piwik.example.com # Required - url to Piwik installation without trailing /
+    siteId: "1234" # Required - replace with your Piwik site id (Write id as string)
 
-  MPulse:                   # Add if you want to track performance with mPulse
-    apikey: XXXXX-YYYYY-ZZZZZ-AAAAA-23456   # Required - replace with your mPulse API key
+  MPulse: # Add if you want to track performance with mPulse
+    apikey: XXXXX-YYYYY-ZZZZZ-AAAAA-23456 # Required - replace with your mPulse API key
 
   Plausible:
-    domain: 'example.com'   # The domain configured in plausible
-    source: 'https://plausible.example.com/js/plausible.js' # The source URL of the javascript,
-    host: 'https://plausible.example.com' # The base URL of the plausible host, only needed for embed_tracker
-    404_tracking: true      # Enable 404 error tracking. Also requires changes to your webserver and 404.md
-                            # See https://plausible.io/docs/404-error-pages-tracking for other set up required
-    embed_tracker: true     # embed the tracking code instead of loading the javascript; this removes one
-                            # call from page loading and circumvents adblockers; this uses `host` to generate
-                            # the correct callback destination
+    domain: "example.com" # The domain configured in plausible
+    source: "https://plausible.example.com/js/plausible.js" # The source URL of the javascript,
+    host: "https://plausible.example.com" # The base URL of the plausible host, only needed for embed_tracker
+    404_tracking:
+      true # Enable 404 error tracking. Also requires changes to your webserver and 404.md
+      # See https://plausible.io/docs/404-error-pages-tracking for other set up required
+    embed_tracker:
+      true # embed the tracking code instead of loading the javascript; this removes one
+      # call from page loading and circumvents adblockers; this uses `host` to generate
+      # the correct callback destination
 
   CounterDotDev:
-    user: 'SomeUser'  # Your username on counter.dev (it is the value for the key "user" on your tracking code)
-    domain: "example.com" # The domain configured in plausible
-    source: "https://plausible.example.com/js/plausible.js" # The source of the javascript
+    data_id: "uuid" # Found in the tracking code/script when you add a website in CounterDotDev
+    source: "https://cdn.counter.dev/script.js" # The source of the javascript
+    data_utc_offset: 8
 
   PostHog:
     url: "https://us.i.posthog.com" # Required - replace with the url of post hog analytics
@@ -81,9 +91,11 @@ jekyll_analytics:
 ```
 
 ## Usage
+
 Tracking will be disabled in development mode. To enable production mode set enviroment variable JEKYLL_ENV=production.
 Github pages automatically sets JEKYLL_ENV to production.
 For testing use
+
 ```
 $ JEKYLL_ENV=production jekyll serve
 ```
@@ -97,17 +109,20 @@ $ JEKYLL_ENV=production jekyll serve
 5. Create a new Pull Request
 
 How to add support for a new tracker:
-1. Create new tracker class in lib/analytics/YourTracker.rb
-  ```
-  #initialize and render must be implemented!
-  class YourTracker
-    def initialize(config)
-      #validate config
-    end
 
-    def render
-      return "Tracking code to insert into html > head"
-    end
-  end
+1. Create new tracker class in lib/analytics/YourTracker.rb
+
 ```
+#initialize and render must be implemented!
+class YourTracker
+  def initialize(config)
+    #validate config
+  end
+
+  def render
+    return "Tracking code to insert into html > head"
+  end
+end
+```
+
 2. Update README.md

--- a/jekyll-analytics.gemspec
+++ b/jekyll-analytics.gemspec
@@ -1,4 +1,3 @@
-
 Gem::Specification.new do |s|
   s.name        = 'jekyll-analytics'
   s.version     = '0.1.12'
@@ -7,7 +6,7 @@ Gem::Specification.new do |s|
   s.description = "Plugin to easily add web analytics to your jekyll site without modifying your templates. Supported are: Google Analytics, Piwik, Matomo, MPulse"
   s.authors     = ["Hendrik Schneider"]
   s.email       = ''
-  s.files       = ["lib/jekyll-analytics.rb", "lib/analytics/GoogleAnalytics.rb", "lib/analytics/Piwik.rb", "lib/analytics/Matomo.rb", "lib/analytics/MPulse.rb"]
+  s.files       = ["lib/jekyll-analytics.rb", "lib/analytics/GoogleAnalytics.rb", "lib/analytics/Piwik.rb", "lib/analytics/Matomo.rb", "lib/analytics/MPulse.rb", "lib/analytics/CounterDotDev.rb", "lib/analytics/plausible.rb", "lib/analytics/post_hog.rb"]
   s.homepage    = 'https://github.com/hendrikschneider/jekyll-analytics'
   s.license     = 'MIT'
 end

--- a/lib/analytics/CounterDotDev.rb
+++ b/lib/analytics/CounterDotDev.rb
@@ -1,17 +1,15 @@
 class CounterDotDev
     def initialize(config)
-        if config['user'].nil?
+        if config['tracking_script'].nil?
             raise ArgumentError, 'Please use your counter.dev "user"'
         end
-
-        @user = config['user']
-
+        @tracking_script = config['tracking_script']
     end
 
     def render()
         str = """
     <!-- Counter.dev Analytics -->
-    <script>if(!sessionStorage.getItem(\"_swa\")&&document.referrer.indexOf(location.protocol+\"//\"+location.host)!== 0){fetch(\"https://counter.dev/track?\"+new URLSearchParams({referrer:document.referrer,screen:screen.width+\"x\"+screen.height,user:\"#{@user}\",utcoffset:\"2\"}))};sessionStorage.setItem(\"_swa\",\"1\");</script>
+    #{@tracking_script}
     <!-- End Counter.dev Analytics  -->
 """
         return str

--- a/lib/analytics/CounterDotDev.rb
+++ b/lib/analytics/CounterDotDev.rb
@@ -1,15 +1,25 @@
 class CounterDotDev
     def initialize(config)
-        if config['tracking_script'].nil?
-            raise ArgumentError, 'Please use your counter.dev "tracking_script"'
+        if config['source'].nil?
+            raise ArgumentError, 'Please use the js "src" found when you add a website in counter.dev.'
         end
-        @tracking_script = config['tracking_script']
+        @source = config['source']
+        if config['data_id'].nil?
+            raise ArgumentError, 'Please use the "data-id" found in the script when you add a website in counter.dev.'
+        end
+        @data_id = config['data_id']
+
+
+        if config['data_utc_offset'].nil?
+            raise ArgumentError, 'Please add a utc offset for the timezone you would want the data to be in.'
+        end
+        @data_utc_offset = config['data_utc_offset']
     end
 
     def render()
         str = """
     <!-- Counter.dev Analytics -->
-    #{@tracking_script}
+    <script src=\"#{@tracking_script}\" data-id=\"#{@data_id}\" data-utcoffset=\"#{@data_utc_offset}\"></script>
     <!-- End Counter.dev Analytics  -->
 """
         return str

--- a/lib/analytics/CounterDotDev.rb
+++ b/lib/analytics/CounterDotDev.rb
@@ -4,11 +4,11 @@ class CounterDotDev
             raise ArgumentError, 'Please use the js "src" found when you add a website in counter.dev.'
         end
         @source = config['source']
+
         if config['data_id'].nil?
             raise ArgumentError, 'Please use the "data-id" found in the script when you add a website in counter.dev.'
         end
         @data_id = config['data_id']
-
 
         if config['data_utc_offset'].nil?
             raise ArgumentError, 'Please add a utc offset for the timezone you would want the data to be in.'
@@ -19,7 +19,7 @@ class CounterDotDev
     def render()
         str = """
     <!-- Counter.dev Analytics -->
-    <script src=\"#{@tracking_script}\" data-id=\"#{@data_id}\" data-utcoffset=\"#{@data_utc_offset}\"></script>
+    <script src=\"#{@source}\" data-id=\"#{@data_id}\" data-utcoffset=\"#{@data_utc_offset}\"></script>
     <!-- End Counter.dev Analytics  -->
 """
         return str

--- a/lib/analytics/CounterDotDev.rb
+++ b/lib/analytics/CounterDotDev.rb
@@ -1,7 +1,7 @@
 class CounterDotDev
     def initialize(config)
         if config['tracking_script'].nil?
-            raise ArgumentError, 'Please use your counter.dev "user"'
+            raise ArgumentError, 'Please use your counter.dev "tracking_script"'
         end
         @tracking_script = config['tracking_script']
     end

--- a/test/CounterDotDev.rb
+++ b/test/CounterDotDev.rb
@@ -13,14 +13,14 @@ class TestCounterDotDev < Test::Unit::TestCase
 
     def test_default_tracking_string
         counterDotDev = CounterDotDev.new({
-            "source" => "https://cdn.counter.dev/script.js",
+            "source" => "https://different.counter.dev/script.js",
             "data_id" => "00000-000000",
             "data_utc_offset" => "2"
         })
         assert_equal(counterDotDev.render(), 
 """
     <!-- Counter.dev Analytics -->
-    <script src=\"https://cdn.counter.dev/script.js\" data-id=\"00000-000000\" data-utcoffset=\"2\"></script>
+    <script src=\"https://different.counter.dev/script.js\" data-id=\"00000-000000\" data-utcoffset=\"2\"></script>
     <!-- End Counter.dev Analytics  -->
 """)
     end

--- a/test/CounterDotDev.rb
+++ b/test/CounterDotDev.rb
@@ -3,28 +3,39 @@ require "test/unit"
 
 class TestCounterDotDev < Test::Unit::TestCase
     def test_init
-        assert_raise( ArgumentError ) { CounterDotDev.new() }
-        assert_instance_of(CounterDotDev, CounterDotDev.new( {"user" => "SomeUser"} ))
+        assert_raise(ArgumentError) { CounterDotDev.new({}) }
+        assert_instance_of(CounterDotDev, CounterDotDev.new({
+            "source" => "https://cdn.counter.dev/script.js",
+            "data_id" => "0006dd92-4e28-4a49-b37e-e76fd3419ffc",
+            "data_utc_offset" => "2"
+        }))
     end
 
     def test_default_tracking_string
-        counterDotDev = CounterDotDev.new( {"user" => "SomeUser"} )
+        counterDotDev = CounterDotDev.new({
+            "source" => "https://cdn.counter.dev/script.js",
+            "data_id" => "00000-000000",
+            "data_utc_offset" => "2"
+        })
         assert_equal(counterDotDev.render(), 
-'''
+"""
     <!-- Counter.dev Analytics -->
-    <script>if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!== 0){fetch("https://counter.dev/track?"+new URLSearchParams({referrer:document.referrer,screen:screen.width+"x"+screen.height,user:"SomeUser",utcoffset:"2"}))};sessionStorage.setItem("_swa","1");</script>
+    <script src=\"https://cdn.counter.dev/script.js\" data-id=\"00000-000000\" data-utcoffset=\"2\"></script>
     <!-- End Counter.dev Analytics  -->
-''')
+""")
     end
 
     def test_other_tracking_string
-        counterDotDev = CounterDotDev.new( {"user" => "SomeOtherUser"} )
+        counterDotDev = CounterDotDev.new({
+            "source" => "https://cdn.counter.dev/script.js",
+            "data_id" => "1234abcd-5678-efgh-ijkl-9876mnopqrst",
+            "data_utc_offset" => "5"
+        })
         assert_equal(counterDotDev.render(), 
-'''
+"""
     <!-- Counter.dev Analytics -->
-    <script>if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!== 0){fetch("https://counter.dev/track?"+new URLSearchParams({referrer:document.referrer,screen:screen.width+"x"+screen.height,user:"SomeOtherUser",utcoffset:"2"}))};sessionStorage.setItem("_swa","1");</script>
+    <script src=\"https://cdn.counter.dev/script.js\" data-id=\"1234abcd-5678-efgh-ijkl-9876mnopqrst\" data-utcoffset=\"5\"></script>
     <!-- End Counter.dev Analytics  -->
-''')
+""")
     end
-
 end


### PR DESCRIPTION
Counterdotdev analytics was not working.
I changed it so that I could just paste the tracking script directly onto the _config.yml

![Screenshot 2025-04-12 at 12 11 30 PM](https://github.com/user-attachments/assets/4faadd21-0e83-43cc-ba25-f56278e496f0)
(How the website asks for tracking)

Note that this still lacks proper test cases.

P.S. I don't code in Ruby, so I don't know if I'm doing this right. 
